### PR TITLE
WIP: A toy example of problems with inline virtual destructors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(support_private_dynamic_cast CXX)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+set(CMAKE_CXX_STANDARD 11)
 option(BASE_DEFAULT_VISIBILITY "Enables default visibility for the
 base class" ON)
 
@@ -11,7 +12,7 @@ if(BASE_DEFAULT_VISIBILITY)
   add_definitions("-DBASE_DEFAULT_VISIBILITY")
 endif()
 
-add_library(base STATIC "base.cxx" "derived.cxx")
+add_library(base SHARED "base.cxx" "derived.cxx")
 set_target_properties(base PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
 add_library(create SHARED "create.cxx")

--- a/base.cxx
+++ b/base.cxx
@@ -1,5 +1,7 @@
 #include "base.h"
 
-base::~base() {}
+void base::something(void)
+{
+}
 
 

--- a/base.h
+++ b/base.h
@@ -8,7 +8,9 @@ __attribute__ ((visibility ("default")))
 #endif
 base
 {
-  virtual ~base() = 0;
+  virtual ~base() = default;
+
+  virtual void something(void);
 };
 
 #endif

--- a/derived.h
+++ b/derived.h
@@ -13,7 +13,7 @@ template <int I>
 struct derivedI
   :public base
 {
-  virtual ~derivedI() {};
+  virtual ~derivedI() = default;
 };
 
 #endif


### PR DESCRIPTION
Demonstrate an issue with using inline default destructors with shared
libraries. When using shared libraries compiling the destructor in a
cxx file for a library is import for vtable construciton in the
library.

[ 57%] Linking CXX shared library libcreate.dylib
Undefined symbols for architecture x86_64:
  "base::something()", referenced from:
      vtable for derivedI<0> in create.cxx.o
  "typeinfo for base", referenced from:
      typeinfo for derivedI<0> in create.cxx.o
  "typeinfo for derived", referenced from:
      create() in create.cxx.o
  "vtable for base", referenced from:
      base::base() in create.cxx.o
  NOTE: a missing vtable usually means the first non-inline virtual
  member function has no definition.
  "vtable for derived", referenced from:
      derived::derived() in create.cxx.o
  NOTE: a missing vtable usually means the first non-inline virtual
  member function has no definition.